### PR TITLE
Implement workflow for creating docker images

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM savasceylan/seismo_at_school:latest
+FROM savasceylan/seismo_at_school:2fd32f8d0a78

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM savasceylan/seismo_at_school:2fd32f8d0a78
+FROM savasceylan/seismo_at_school:distribution

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM your-dockerhub-username/seismo_at_school:latest
+FROM savasceylan/seismo_at_school:latest

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,0 +1,1 @@
+FROM your-dockerhub-username/seismo_at_school:latest

--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -25,15 +25,11 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Install repo2docker
-      run: |
-        python -m pip install --upgrade pip
-        pip install jupyter-repo2docker
-
-    - name: Build and push Docker image to Binder cache and Docker Hub
+    - name: Build and push Docker image
       env:
         MYBINDERORG_CACHE: true
       run: |
-        jupyter-repo2docker --no-run --user-name jovyan --user-id 1000 --image-name savasceylan/seismo_at_school .
+        # Build the Docker image locally from the Dockerfile
         docker build -t savasceylan/seismo_at_school:latest .
+        # Push the Docker image to Docker Hub
         docker push savasceylan/seismo_at_school:latest

--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -1,0 +1,39 @@
+name: Build and Push Docker image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Install repo2docker
+      run: |
+        python -m pip install --upgrade pip
+        pip install jupyter-repo2docker
+
+    - name: Build and push Docker image to Binder cache and Docker Hub
+      env:
+        MYBINDERORG_CACHE: true
+      run: |
+        jupyter-repo2docker --no-run --user-name jovyan --user-id 1000 --image-name savasceylan/seismo_at_school .
+        docker build -t savasceylan/seismo_at_school:latest .
+        docker push savasceylan/seismo_at_school:latest

--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -29,7 +29,8 @@ jobs:
       env:
         MYBINDERORG_CACHE: true
       run: |
+        IMAGE_TAG="distribution"
         # Build the Docker image locally from the Dockerfile
-        docker build -t savasceylan/seismo_at_school:latest .
+        docker build -t savasceylan/seismo_at_school:$IMAGE_TAG .
         # Push the Docker image to Docker Hub
-        docker push savasceylan/seismo_at_school:latest
+        docker push savasceylan/seismo_at_school:$IMAGE_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,8 @@ COPY . /app
 # Install dependencies specified in requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-# Specify entrypoint if needed, but no need to run Jupyter
-CMD ["bash"]
+# Expose the Jupyter Notebook port
+EXPOSE 8888
+
+# Run Jupyter Notebook
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,50 @@
 # Use Ubuntu 22.04 as a base image
 FROM ubuntu:22.04
 
-# Set the working directory in the container
-WORKDIR /app
-
 # Update and install Python, pip, and other necessary packages
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
     wget \
     git \
+    tini \
     && apt-get clean
 
-# Install Jupyter and other Python dependencies
-RUN python3 -m pip install --no-cache-dir notebook jupyterlab
+# Add a user id with 1000. 
+ARG NB_USER=jovyan
+ARG NB_UID=1000
+ENV USER ${NB_USER}
+ENV NB_UID ${NB_UID}
+ENV HOME /home/${NB_USER}
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
 
-# Copy the current directory contents into the container at /app
-COPY . /app
+# Make sure the contents of our repo are in ${HOME}
+COPY . ${HOME}
+USER root
+RUN chown -R ${NB_UID} ${HOME}
+USER ${NB_USER}
 
-# Install dependencies specified in requirements.txt
-RUN pip3 install --no-cache-dir -r requirements.txt
+# Set the working directory in the container
+WORKDIR ${HOME}
+
+# Ensure that /usr/local/bin is in the PATH
+ENV PATH="/usr/local/bin:/home/jovyan/.local/bin/:${PATH}"
 
 # Expose the Jupyter Notebook port
 EXPOSE 8888
 
-# Run Jupyter Notebook with debugging
-CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--log-level=DEBUG"]
+# Install Jupyter and other Python dependencies
+RUN python3 -m pip install --no-cache-dir notebook jupyterlab
+
+# Install dependencies specified in requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Set ENTRYPOINT to handle the arguments passed by Binder
+ENTRYPOINT ["tini", "-g", "--"]
+
+# Default command to start Jupyter Notebook
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--NotebookApp.default_url=/lab/"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,16 @@ FROM ubuntu:22.04
 # Set the working directory in the container
 WORKDIR /app
 
-# Update and install Python and pip
+# Update and install Python, pip, and other necessary packages
 RUN apt-get update && apt-get install -y \
     python3 \
-    python3-pip
+    python3-pip \
+    wget \
+    git \
+    && apt-get clean
+
+# Install Jupyter and other Python dependencies
+RUN python3 -m pip install --no-cache-dir notebook jupyterlab
 
 # Copy the current directory contents into the container at /app
 COPY . /app
@@ -18,5 +24,5 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Expose the Jupyter Notebook port
 EXPOSE 8888
 
-# Run Jupyter Notebook
-CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]
+# Run Jupyter Notebook with debugging
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--log-level=DEBUG"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use Ubuntu 22.04 as a base image
+FROM ubuntu:22.04
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Update and install Python and pip
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install dependencies specified in requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Specify entrypoint if needed, but no need to run Jupyter
+CMD ["bash"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy==1.26.0
 obspy
 matplotlib
 cartopy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ obspy
 matplotlib
 cartopy
 ipywidgets
+jupyter
+requests
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ obspy
 matplotlib
 cartopy
 ipywidgets
-jupyter
 requests
 


### PR DESCRIPTION
This update allows to distribute the seismo-at-school codes into docker containers. The numpy version is fixed to avoid a bug in obspy.taup due to the ```np.float_``` deprecation in the latest version of numpy 2.0. Docker images make the load-up time on Binder much faster. 